### PR TITLE
Potential fix for code scanning alert no. 134: Unused import

### DIFF
--- a/src/mneme/mneme_storage_core.py
+++ b/src/mneme/mneme_storage_core.py
@@ -22,7 +22,7 @@ import sqlite3
 import tempfile
 import shutil
 import weakref
-from threading import Lock, RLock
+from threading import Lock
 from collections import deque, OrderedDict
 import safetensors
 from safetensors.torch import save_file, load_file


### PR DESCRIPTION
Potential fix for [https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/134](https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/134)

To fix this issue, we should remove the unused import of `RLock` from the `from threading import Lock, RLock` statement. This will reduce confusion, clarify dependencies, simplify code, and quiet the CodeQL warning.

Specifically, edit line 25 in `src/mneme/mneme_storage_core.py` to import only `Lock` from the `threading` module, removing `RLock`. No other changes are necessary, as the import of `Lock` remains.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
