### PR TITLE
Potential fix for code scanning alert no. 146: Wrong name for an argument in a class instantiation

### DIFF
--- a/tests/test_mneme.py
+++ b/tests/test_mneme.py
@@ -386,7 +386,7 @@ class TestMNEMESecurity(unittest.TestCase):
     
     def test_security_status(self):
         """Probar estado de seguridad"""
-        security_manager = SecurityManager(security_level=SecurityLevel.STANDARD)
+        security_manager = SecurityManager(level=SecurityLevel.STANDARD)
         
         status = security_manager.get_security_status()
         


### PR DESCRIPTION
Potential fix for [https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/146](https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/146)

To fix the problem, you need to change the argument name in the instantiation of `SecurityManager` on line 389 from `security_level` to the correct keyword expected by the constructor. Typically, if the enum is called `SecurityLevel`, the constructor argument may just be `level`, but the exact name depends on how `SecurityManager` is defined. Given that CodeQL rejected `security_level`, but did not flag line 346, it's possible that either (1) the constructor accepts only positional arguments, or (2) a different parameter name was used elsewhere. 

Since the most likely parameter is `level`, and since both line 346 and 370 use the (now-flagged) `security_level=` argument, but only 389 has triggered the error, double-checking for consistency is important. If the correct parameter is `level`, all three occurrences should be fixed. But as only line 389 is flagged, perhaps only that instantiation is problematic (for example, if the constructor signature changed after some refactoring and not all usages were updated).

**Best fix:**  
Change the argument in line 389 from `security_level=SecurityLevel.STANDARD` to `level=SecurityLevel.STANDARD`, matching the expected constructor parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
