### PR TITLE
Potential fix for code scanning alert no. 150: Except block handles 'BaseException'

### DIFF
--- a/src/mneme/mneme_storage_core.py
+++ b/src/mneme/mneme_storage_core.py
@@ -159,7 +159,7 @@ class SecureStorageBackend:
         """Descomprimir datos de forma segura"""
         try:
             return lz4.frame.decompress(data)
-        except:
+        except Exception:
             # Si falla la descompresión, asumir que no está comprimido
             return data
     


### PR DESCRIPTION
Potential fix for [https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/150](https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/150)

To resolve the issue, the bare `except:` at line 162 should be replaced by either a more precise exception clause or at minimum `except Exception:`. The intention is to catch decompression errors (such as corrupted or uncompressed data), so it suffices—and is preferable—to catch only exceptions that derive from `Exception`, thereby letting user interrupts and system exits propagate. The specific fix is: in the `_decompress_data` method, change the `except:` at line 162 to `except Exception:`. No new imports or other code changes are required, as ordinary exception handling already works as intended elsewhere in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
