### PR TITLE
Potential fix for code scanning alert no. 162: Wrong name for an argument in a class instantiation

### DIFF
--- a/tests/test_mneme.py
+++ b/tests/test_mneme.py
@@ -386,7 +386,7 @@ class TestMNEMESecurity(unittest.TestCase):
     
     def test_security_status(self):
         """Probar estado de seguridad"""
-        security_manager = SecurityManager(level=SecurityLevel.STANDARD)
+        security_manager = SecurityManager(security_level=SecurityLevel.STANDARD)
         
         status = security_manager.get_security_status()
         


### PR DESCRIPTION
Potential fix for [https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/162](https://github.com/esraderey/MNEME---Motor-de-Memoria-Neural-M-rfica/security/code-scanning/162)

To fix the issue, update the instantiation of the `SecurityManager` class on line 389 in file `tests/test_mneme.py`. Change the keyword argument from `level` to `security_level`, as used throughout the rest of the test file and likely matching the constructor definition for `SecurityManager`. No additional imports, definitions, or method changes are necessary. The patch consists of a single keyword argument update within the code block of `test_security_status`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
